### PR TITLE
SmartOS service install

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ and print all config as JSON.
 tacodb logs --name foo --tail --since now
 ```
 
+## SmartOS Deploy 
+
+Running the following actions will enable tacodb as a service on SmartOS
+The default is port 8000 as defined in the ```exec_method``` tag.
+N.B Test on Standard64 1.0.7 with a downloaded install of node.js 0.10.10 
+
+```
+# cd deploy
+# svccfg import tacodb-service-manifest.xml 
+# svcadm enable tacodb-service
+```
+
 ## License
 
 MIT

--- a/deploy/tacodb-service-manifest.xml
+++ b/deploy/tacodb-service-manifest.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest" name="tacodb-service">
+  <service name="site/tacodb-service" type="service" version="1">
+
+    <create_default_instance enabled="true"/>
+
+    <single_instance/>
+
+    <dependency name="network" grouping="require_all" restart_on="refresh" type="service">
+          <service_fmri value="svc:/milestone/network:default"/>
+              </dependency>
+
+    <dependency name="filesystem" grouping="require_all" restart_on="refresh" type="service">
+          <service_fmri value="svc:/system/filesystem/local"/>
+              </dependency>
+
+    <method_context working_directory="/home/admin">
+          <method_credential user="admin" group="staff" privileges='basic,net_privaddr'  />
+                <method_environment>
+                        <envvar name="PATH" value="/opt/local/gnu/bin:/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin"/>
+                                <envvar name="HOME" value="/home/admin"/>
+                                <envvar name="LD_LIBRARY_PATH" value="/opt/local/gcc47/lib/amd64"/>
+                                      </method_environment>
+                                          </method_context>
+
+    <exec_method
+          type="method"
+                name="start"
+                      exec="tacodb start --port 8000"
+                            timeout_seconds="60"/>
+
+    <exec_method
+          type="method"
+                name="stop"
+                      exec=":kill"
+                            timeout_seconds="60"/>
+
+    <property_group name="startd" type="framework">
+          <propval name="duration" type="astring" value="child"/>
+                <propval name="ignore_error" type="astring" value="core,signal"/>
+                    </property_group>
+
+    <property_group name="application" type="application">
+
+    </property_group>
+
+
+    <stability value="Evolving"/>
+
+    <template>
+          <common_name>
+                  <loctext xml:lang="C">node.js tacodb service</loctext>
+                        </common_name>
+                            </template>
+
+  </service>
+  </service_bundle>


### PR DESCRIPTION
Added a file into a new folder called deploy that allows for tacodb to be ran as an SmartOS Service. 
Instructions in the README. Under SmartOS Deploy
